### PR TITLE
Fix finger tip transform, so collision body is at fingertip, not at wrist

### DIFF
--- a/TimeForCube/ModelEntity+Extension.swift
+++ b/TimeForCube/ModelEntity+Extension.swift
@@ -19,7 +19,7 @@ extension ModelEntity {
     )
     
     entity.components.set(PhysicsBodyComponent(mode: .kinematic))
-    entity.components.set(OpacityComponent(opacity: 0.0))
+    entity.components.set(OpacityComponent(opacity: 0.0))  // comment out this line to visualize the fingertip tracker
     
     return entity
   }


### PR DESCRIPTION
Changed parentFromJointTransform to anchorFromJointTransform; the former only gives the transform from the previous joint, which is the distal interphalangeal joint; the latter gives the transform from the wrist.

Also added commented-out code documenting how to inspect the skeleton